### PR TITLE
fix several bugs

### DIFF
--- a/src/com/yyztom/pathfinding/astar/AStar.as
+++ b/src/com/yyztom/pathfinding/astar/AStar.as
@@ -67,6 +67,7 @@ package com.yyztom.pathfinding.astar
 			
 			
 			_openHeap.push(start);
+			_touched[i++] = start;
 			
 			while( _openHeap.size > 0 ){
 				currentNode = _openHeap.pop();
@@ -87,7 +88,6 @@ package com.yyztom.pathfinding.astar
 				}
 				
 				currentNode.closed = true;
-				_touched[i++] = currentNode;
 				
 				for each(neighbor in currentNode.neighbors)	{
 					if (neighbor.closed)
@@ -157,9 +157,9 @@ package com.yyztom.pathfinding.astar
 				d2 : int = pos1.y - pos0.y;
 			d1 = d1 < 0 ? -d1 : d1;
 			d2 = d2 < 0 ? -d2 : d2;
-			//diag = d1 < d2 ? d1 : d2;
+			var diag:int = d1 > d2 ? d1 : d2;
 			//return  Math.SQRT2 * diag + d1 + d2 - 2 * diag;
-			return d1 + d2;
+			return diag;
 		}
 		
 	}

--- a/src/com/yyztom/pathfinding/astar/BinaryHeap.as
+++ b/src/com/yyztom/pathfinding/astar/BinaryHeap.as
@@ -91,8 +91,8 @@ package com.yyztom.pathfinding.astar
 			while (n > 0) {
 				
 				// Compute the parent element's index, and fetch it.
-				//var parentN : Number = ((n + 1) >> 1) -1 ;
-				var parentN : Number = _content.indexOf(element.parent);
+				var parentN : Number = ((n + 1) >> 1) -1 ;
+				//var parentN : Number = _content.indexOf(element.parent);
 				if (parentN == -1 ){
 					parentN = 0;
 				}


### PR DESCRIPTION
Hi,

the paths found in your implementation are not always optimal. E.g. in the picture below, the green circle shows an obvious possibility to shorten the found path by walking diagonally. 
![](https://cloud.githubusercontent.com/assets/2026226/6885536/93f01e18-d624-11e4-904c-2ba8c63d4839.png)

One reason for this is that the order of the nodes in the binary heap is not correct, because the sinkDown() method computes the current node's parent in the wrong way.

Also, the used heuristic, i.e. the method heuristic() in the class AStar sometimes overestimates the distance to the end point, which might lead to suboptimal results. See [Wikipedia](http://en.wikipedia.org/w/index.php?title=A*_search_algorithm&oldid=649438130#Description): "The h(x) part of the f(x) function must be an admissible heuristic; that is, it must not overestimate the distance to the goal."

Furthermore the _touched vector in the AStar class contains most nodes twice, which is completely unnecessary. It's enough to store every touched node once. Also, storing nodes twice can lead to an error when the algorithm tries to write beyond the end of the vector.

My commit (hopefully) fixes all the mentioned problems.
