### PR TITLE
fix of behaviour if no path was found

### DIFF
--- a/src/com/yyztom/pathfinding/astar/AStar.as
+++ b/src/com/yyztom/pathfinding/astar/AStar.as
@@ -118,7 +118,7 @@ package com.yyztom.pathfinding.astar
 				}
 			}
 			
-			return ret;
+			return null;
 		}
 		
 		

--- a/src/com/yyztom/test/ui/Demo.as
+++ b/src/com/yyztom/test/ui/Demo.as
@@ -113,6 +113,10 @@ com.yyztom.test.ui{
 				_grid[node2.position.x][node2.position.y].drawWasEvaluated();
 			}
 			
+			if (result == null) {
+				return;
+			}
+			
 			for each ( var node:AStarNodeVO in result )
 				_grid[node.position.x][node.position.y].drawForPath();
 			


### PR DESCRIPTION
- the search returns null instead of an old path
- the gui can handle null values returned from the search. This would
  also be necessary without the first fix, because the previously returned
  old path might be null anyway.
